### PR TITLE
Adjust tray indicator size and outline

### DIFF
--- a/InvisibleMan-XRay/Factories/WindowFactory.cs
+++ b/InvisibleMan-XRay/Factories/WindowFactory.cs
@@ -51,6 +51,8 @@ namespace InvisibleManXRay.Factories
                 onStopServer: core.Stop,
                 onCancelServer: core.Cancel,
                 onDisableMode: core.DisableMode,
+                getMode: settingsHandler.UserSettings.GetMode,
+                setTrayIndicator: handlersManager.GetHandler<NotifyHandler>().SetIndicator,
                 onGenerateClientId: settingsHandler.GenerateClientId,
                 onGitHubClick: linkHandler.OpenGitHubRepositoryLink,
                 onBugReportingClick: linkHandler.OpenBugReportingLink,
@@ -107,6 +109,7 @@ namespace InvisibleManXRay.Factories
                 localizationHandler.TryApplyCurrentLanguage();
                 notifyHandler.InitializeNotifyIcon();
                 notifyHandler.CheckModeItem(userSettings.GetMode());
+                notifyHandler.SetIndicator(null);
                 GetMainWindow().TryDisableModeAndRerun();
             }
         }

--- a/InvisibleMan-XRay/Handlers/NotifyHandler.cs
+++ b/InvisibleMan-XRay/Handlers/NotifyHandler.cs
@@ -2,6 +2,7 @@ using System;
 using System.Linq;
 using System.Drawing;
 using System.Windows.Forms;
+using System.Drawing.Drawing2D;
 using System.Collections.Generic;
 
 namespace InvisibleManXRay.Handlers
@@ -14,6 +15,7 @@ namespace InvisibleManXRay.Handlers
     public class NotifyHandler : Handler
     {
         private NotifyIcon notifyIcon;
+        private Icon baseIcon;
 
         private Func<Mode> getMode;
         private Action onOpenClick;
@@ -61,6 +63,7 @@ namespace InvisibleManXRay.Handlers
 
             notifyIcon = new NotifyIcon();
             notifyIcon.Icon = GetNotifyIcon();
+            baseIcon = notifyIcon.Icon;
             notifyIcon.Visible = true;
 
             HandleNotifyIconClick();
@@ -182,5 +185,45 @@ namespace InvisibleManXRay.Handlers
         {
             item.Checked = true;
         }
+
+        public void SetIndicator(Mode? mode)
+        {
+            if (notifyIcon == null || baseIcon == null)
+                return;
+
+            if (mode == null)
+            {
+                notifyIcon.Icon = baseIcon;
+                return;
+            }
+
+            Color color = mode == Mode.TUN ? Color.Red : Color.Blue;
+            notifyIcon.Icon = CreateIndicatorIcon(color);
+        }
+
+        private Icon CreateIndicatorIcon(Color color)
+        {
+            using (Bitmap bmp = baseIcon.ToBitmap())
+            using (Graphics g = Graphics.FromImage(bmp))
+            using (Brush brush = new SolidBrush(color))
+            using (Pen outline = new Pen(Color.White, 1))
+            {
+                int size = bmp.Width / 3 + 2;
+                int x = bmp.Width - size - 1;
+                int y = bmp.Height - size - 1;
+
+                g.SmoothingMode = SmoothingMode.AntiAlias;
+                g.FillEllipse(brush, x, y, size, size);
+                g.DrawEllipse(outline, x, y, size, size);
+
+                IntPtr hIcon = bmp.GetHicon();
+                Icon icon = (Icon)Icon.FromHandle(hIcon).Clone();
+                DestroyIcon(hIcon);
+                return icon;
+            }
+        }
+
+        [System.Runtime.InteropServices.DllImport("user32.dll", CharSet = System.Runtime.InteropServices.CharSet.Auto)]
+        private static extern bool DestroyIcon(IntPtr handle);
     }
 }

--- a/InvisibleMan-XRay/Windows/MainWindow/MainWindow.xaml.cs
+++ b/InvisibleMan-XRay/Windows/MainWindow/MainWindow.xaml.cs
@@ -31,6 +31,8 @@ namespace InvisibleManXRay
         private Action onCancelServer;
         private Action onStopServer;
         private Action onDisableMode;
+        private Func<Mode> getMode;
+        private Action<Mode?> setTrayIndicator;
         private Action onGenerateClientId;
         private Action onGitHubClick;
         private Action onBugReportingClick;
@@ -230,6 +232,8 @@ namespace InvisibleManXRay
             Action onStopServer,
             Action onCancelServer,
             Action onDisableMode,
+            Func<Mode> getMode,
+            Action<Mode?> setTrayIndicator,
             Action onGenerateClientId,
             Action onGitHubClick,
             Action onBugReportingClick,
@@ -252,12 +256,15 @@ namespace InvisibleManXRay
             this.onStopServer = onStopServer;
             this.enableMode = enableMode;
             this.onDisableMode = onDisableMode;
+            this.getMode = getMode;
+            this.setTrayIndicator = setTrayIndicator;
             this.onGenerateClientId = onGenerateClientId;
             this.onGitHubClick = onGitHubClick;
             this.onBugReportingClick = onBugReportingClick;
             this.onCustomLinkClick = onCustomLinkClick;
 
             UpdateUI();
+            setTrayIndicator(null);
         }
 
         protected override void OnContentRendered(EventArgs e)
@@ -433,6 +440,7 @@ namespace InvisibleManXRay
             buttonStop.Visibility = Visibility.Visible;
             buttonCancel.Visibility = Visibility.Hidden;
             buttonRun.Visibility = Visibility.Hidden;
+            setTrayIndicator(getMode.Invoke());
         }
 
         private void ShowStopStatus()
@@ -444,6 +452,7 @@ namespace InvisibleManXRay
             buttonRun.Visibility = Visibility.Visible;
             buttonCancel.Visibility = Visibility.Hidden;
             buttonStop.Visibility = Visibility.Hidden;
+            setTrayIndicator(null);
         }
 
         private void ShowWaitForRunStatus()
@@ -455,6 +464,7 @@ namespace InvisibleManXRay
             buttonCancel.Visibility = Visibility.Visible;
             buttonRun.Visibility = Visibility.Hidden;
             buttonStop.Visibility = Visibility.Hidden;
+            setTrayIndicator(null);
         }
 
         protected override void OnClosing(CancelEventArgs e)


### PR DESCRIPTION
## Summary
- tweak `NotifyHandler.CreateIndicatorIcon` so indicator dot is 2px larger
- use 1px outline to keep indicator crisp

## Testing
- `dotnet build InvisibleMan-XRay.sln -clp:ErrorsOnly` *(fails: Microsoft.NET.Sdk.WindowsDesktop missing)*

------
https://chatgpt.com/codex/tasks/task_e_6851857b7fa4832d89d803138515404c